### PR TITLE
🐛 Adding brackets to correct operator precedence. Fixes #7

### DIFF
--- a/Commands.cs
+++ b/Commands.cs
@@ -129,10 +129,14 @@ namespace JifBot.Commands
                 waitTime += Convert.ToInt32(Regex.Match(message, @"-m *[0-9]+").Value.Replace("-m", ""));
 
             if (Regex.IsMatch(message, @"-h *[0-9]+"))
-                waitTime += Convert.ToInt32(Regex.Match(message, @"-h *[0-9]+").Value.Replace("-h", "")) * 60;
+            {
+                waitTime += (Convert.ToInt32(Regex.Match(message, @"-h *[0-9]+").Value.Replace("-h", "")) * 60);
+            }
 
             if (Regex.IsMatch(message, @"-d *[0-9]+"))
-                waitTime += Convert.ToInt32(Regex.Match(message, @"-d *[0-9]+").Value.Replace("-d", "")) * 1440;
+            {
+                waitTime += (Convert.ToInt32(Regex.Match(message, @"-d *[0-9]+").Value.Replace("-d", "")) * 1440);
+            }
 
             if (waitTime == 0)
             {


### PR DESCRIPTION
@Vertigeux I believe this bug was caused by a problem in operator precedence. I've inserted some brackets and braces to make the behaviour more explicit.