### PR TITLE
🐛 Change udefine command to check net thumbs up to thumbs down ratio

### DIFF
--- a/Commands/Information.cs
+++ b/Commands/Information.cs
@@ -238,10 +238,11 @@ namespace JifBot.Commands
 
                 foreach (UrbanDictionaryDefinition definition in definitionList)
                 {
-                    if (definition.thumbs_up > currVote)
+                    int netThumbs = definition.thumbs_up - definition.thumbs_down;
+                    if (netThumbs > currVote)
                     {
                         currDefinition = definition;
-                        currVote = definition.thumbs_up;
+                        currVote = netThumbs;
                     }
                 }
 


### PR DESCRIPTION
As stated in the title, it's been found that some definitions can have a high ratio of thumbs down to thumbs up, which may indicated that a definition may not be the best one of a bunch eg. [Nelly](https://www.urbandictionary.com/define.php?term=Nelly)